### PR TITLE
Upgrade to .NET 6 RC2

### DIFF
--- a/DistributedResponseCachingMiddleware/Custom/CustomResponseCachingServiceExtensions.cs
+++ b/DistributedResponseCachingMiddleware/Custom/CustomResponseCachingServiceExtensions.cs
@@ -62,6 +62,10 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 services.AddCacheAuthorizedRequestsResponseCachingPolicy();
             }
+            else
+            {
+                services.AddSingleton<IResponseCachingPolicyProvider, ResponseCachingPolicyProvider>();
+            }
             services.AddResponseCaching();
             return services;
         }

--- a/DistributedResponseCachingMiddleware/Custom/CustomResponseCachingServiceExtensions.cs
+++ b/DistributedResponseCachingMiddleware/Custom/CustomResponseCachingServiceExtensions.cs
@@ -48,7 +48,15 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var options = new CustomResponseCachingOptions();
             configureOptions(options);
+
             services.Configure(configureOptions);
+            services.Configure<ResponseCachingOptions>(baseOptions =>
+            {
+                baseOptions.SizeLimit = options.SizeLimit;
+                baseOptions.MaximumBodySize = options.MaximumBodySize;
+                baseOptions.UseCaseSensitivePaths = options.UseCaseSensitivePaths;
+                baseOptions.SystemClock = options.SystemClock;
+            });
 
             _ = options.ResponseCachingStrategy switch
             {

--- a/DistributedResponseCachingMiddleware/DistributedResponseCachingMiddleware.csproj
+++ b/DistributedResponseCachingMiddleware/DistributedResponseCachingMiddleware.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
-	<Version>3.0.2</Version>
+	<Version>6.0.0-rc.2</Version>
 	<Description>An alternative to Microsoft.AspNetCore.ResponseCaching, which supports IDistributedCache, allows custom reponse caches, and provides a modifiable distributed response cache, which uses an injecting distributed cache, and options which allow clearing or ignoring the cache.
 It uses Microsoft.AspNetCore.ResponseCaching internally (via git submodule and linking in csproj)</Description>
 	<PackageProjectUrl></PackageProjectUrl>
@@ -33,18 +33,21 @@ It uses Microsoft.AspNetCore.ResponseCaching internally (via git submodule and l
   </PropertyGroup>
 
 	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>DistributedResponseCachingMiddlewareTests</_Parameter1>
+		</AssemblyAttribute>
 		<Compile Include="..\aspnetcore\src\Middleware\ResponseCaching\src\**\*.cs" Exclude="..\aspnetcore\src\Middleware\ResponseCaching\src\obj\**\*.*">
 			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
 		</Compile>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="2.1.1" />
-	  <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.6" />
-	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="2.2.0" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0-rc.2.21480.5" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0-rc.2.21480.5" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-rc.2.21480.5" />
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DistributedResponseCachingMiddlewareTests/DistributedResponseCacheTests.cs
+++ b/DistributedResponseCachingMiddlewareTests/DistributedResponseCacheTests.cs
@@ -1,17 +1,17 @@
-using NUnit.Framework;
-using Moq;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.AspNetCore.ResponseCaching.Internal;
-using System;
-using System.IO;
-using Microsoft.AspNetCore.Http;
-using System.Collections.Generic;
-using Microsoft.Extensions.Primitives;
-using System.Threading;
 using ExternalNetcoreExtensions.Distributed;
-using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCaching;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
 
 namespace DistributedResponseCachingMiddlewareTests
 {

--- a/DistributedResponseCachingMiddlewareTests/DistributedResponseCachingMiddlewareTests.csproj
+++ b/DistributedResponseCachingMiddlewareTests/DistributedResponseCachingMiddlewareTests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 	<LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.6" />
-    <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WeatherApi/WeatherApi.csproj
+++ b/WeatherApi/WeatherApi.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0-rc.2.21480.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix compilation errors:
- Expose internals of DistributedResponseCachingMiddleware to DistributedResponseCachingMiddlewareTests. This fixes #5.
- Consider new namespace of CachedResponse

Upgradef to NET 6 RC2:
- Set target framework to net6.0
- Updated nuget packages to 6.0 or latest
- Set Version to 6.0.0-rc2

Bugfixes:
- Register ResponseCachingPolicyProvider as IResponseCachingPolicyProvider when CacheAuthorizedRequest is not enabled, to fix error when resolving for IResponseCachingPolicyProvider
- Fix configuration of ResponseCachingOptions by configuring it explicitly. By just registering the CustomResponseCachingOptions, the options of the base objects would get lost when resolving for IOptions<ResponseCachingOptions>.